### PR TITLE
feat: module-timestamp

### DIFF
--- a/modules/module-timestamp/CHANGELOG.md
+++ b/modules/module-timestamp/CHANGELOG.md
@@ -1,0 +1,19 @@
+# Change Log
+
+All notable changes to this project will be documented in this file.
+See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
+
+## [0.2.1](https://github.com/eventvisor/eventvisor/compare/v0.2.0...v0.2.1) (2025-10-01)
+
+**Note:** Version bump only for package @eventvisor/module-uuid
+
+
+
+
+
+# [0.2.0](https://github.com/eventvisor/eventvisor/compare/v0.1.0...v0.2.0) (2025-10-01)
+
+
+### Features
+
+* module-uuid ([#3](https://github.com/eventvisor/eventvisor/issues/3)) ([7c5d5d1](https://github.com/eventvisor/eventvisor/commit/7c5d5d166fd519a484b0f146a666cb40bac1180a))

--- a/modules/module-timestamp/README.md
+++ b/modules/module-timestamp/README.md
@@ -1,0 +1,9 @@
+# @eventvisor/module-timestamp
+
+> Timestamp module for Eventvisor, for generating timestamps.
+
+Visit [https://eventvisor.org/docs/modules/timestamp/](https://eventvisor.org/docs/modules/timestamp/) for more information.
+
+## License
+
+MIT © [Fahad Heylaal](https://fahad19.com)

--- a/modules/module-timestamp/jest.config.js
+++ b/modules/module-timestamp/jest.config.js
@@ -1,0 +1,5 @@
+module.exports = {
+  preset: "ts-jest",
+  bail: true,
+  collectCoverageFrom: ["src/**/*.ts"],
+};

--- a/modules/module-timestamp/package.json
+++ b/modules/module-timestamp/package.json
@@ -1,0 +1,45 @@
+{
+  "name": "@eventvisor/module-timestamp",
+  "version": "0.2.1",
+  "description": "Eventvisor Timestamp module",
+  "main": "dist/index.cjs.js",
+  "module": "dist/index.mjs",
+  "types": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "require": "./dist/index.js",
+      "import": "./dist/index.mjs"
+    },
+    "./package.json": "./package.json"
+  },
+  "scripts": {
+    "transpile": "echo 'Nothing to transpile'",
+    "dist": "webpack --config ./webpack.config.js && tsc --project tsconfig.esm.json --declaration --emitDeclarationOnly --declarationDir dist",
+    "build": "npm run transpile && npm run dist",
+    "test:jest": "jest --config jest.config.js --verbose",
+    "test:jest-coverage": "jest --config jest.config.js --verbose --coverage",
+    "test": "npm run test:jest-coverage"
+  },
+  "author": {
+    "name": "Fahad Heylaal",
+    "url": "https://fahad19.com"
+  },
+  "homepage": "https://eventvisor.org",
+  "keywords": [],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/eventvisor/eventvisor.git"
+  },
+  "publishConfig": {
+    "access": "public",
+    "registry": "https://registry.npmjs.org/"
+  },
+  "bugs": {
+    "url": "https://github.com/eventvisor/eventvisor/issues"
+  },
+  "devDependencies": {
+    "@eventvisor/sdk": "0.2.1"
+  },
+  "license": "MIT"
+}

--- a/modules/module-timestamp/src/index.spec.ts
+++ b/modules/module-timestamp/src/index.spec.ts
@@ -1,0 +1,27 @@
+import { createTimestampModule } from "./index";
+import { ModuleDependencies } from "@eventvisor/sdk";
+
+describe("createTimestampModule", () => {
+  it("should create a module", async () => {
+    const module = createTimestampModule();
+    const dependencies = {} as ModuleDependencies; // it's fine because we're not using the dependencies in this module
+
+    expect(module.name).toEqual("timestamp");
+
+    // epoch
+    const epochTimestamp = await module.lookup?.({ key: "epoch" }, dependencies);
+    expect(epochTimestamp).toBeDefined();
+    expect(epochTimestamp).toBeGreaterThan(0);
+    expect(epochTimestamp).toBeLessThanOrEqual(Math.floor(Date.now() / 1000));
+
+    // epoch_ms
+    const epochMsTimestamp = await module.lookup?.({ key: "epoch_ms" }, dependencies);
+    expect(epochMsTimestamp).toBeDefined();
+    expect(epochMsTimestamp).toBeLessThanOrEqual(Date.now());
+
+    // default (iso 8601 with offset)
+    const defaultTimestamp = await module.lookup?.({ key: "" }, dependencies);
+    expect(defaultTimestamp).toBeDefined();
+    expect(defaultTimestamp).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}\+\d{2}:\d{2}$/);
+  });
+});

--- a/modules/module-timestamp/src/index.ts
+++ b/modules/module-timestamp/src/index.ts
@@ -1,0 +1,44 @@
+import { Module } from "@eventvisor/sdk";
+
+export type TimestampModuleOptions = {
+  name?: string;
+};
+
+export function toLocalIsoOffset(d = new Date()) {
+  const pad = (n, len = 2) => String(n).padStart(len, "0");
+  const offMin = -d.getTimezoneOffset();
+  const sign = offMin >= 0 ? "+" : "-";
+  const hh = pad(Math.floor(Math.abs(offMin) / 60));
+  const mm = pad(Math.abs(offMin) % 60);
+
+  return (
+    `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}` +
+    `T${pad(d.getHours())}:${pad(d.getMinutes())}:${pad(d.getSeconds())}` +
+    `.${pad(d.getMilliseconds(), 3)}${sign}${hh}:${mm}`
+  );
+}
+
+export function createTimestampModule(options: TimestampModuleOptions = {}): Module {
+  const { name = "timestamp" } = options;
+
+  return {
+    name,
+
+    lookup: async ({ key }) => {
+      if (key) {
+        if (key === "epoch") {
+          // seconds
+          return Math.floor(Date.now() / 1000);
+        }
+
+        if (key === "epoch_ms") {
+          // milliseconds
+          return Date.now();
+        }
+      }
+
+      // iso 8601 with offset
+      return toLocalIsoOffset();
+    },
+  };
+}

--- a/modules/module-timestamp/tsconfig.cjs.json
+++ b/modules/module-timestamp/tsconfig.cjs.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.cjs.json",
+  "compilerOptions": {
+    "outDir": "./lib",
+    "lib": ["DOM"]
+  },
+  "include": ["./src/**/*.ts"]
+}

--- a/modules/module-timestamp/tsconfig.esm.json
+++ b/modules/module-timestamp/tsconfig.esm.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.esm.json",
+  "compilerOptions": {
+    "outDir": "./lib",
+    "lib": ["DOM"]
+  },
+  "include": ["./src/**/*.ts"]
+}

--- a/modules/module-timestamp/webpack.config.js
+++ b/modules/module-timestamp/webpack.config.js
@@ -1,0 +1,80 @@
+const path = require("path");
+
+module.exports = [
+  // cjs
+  {
+    entry: {
+      "index.cjs": path.join(__dirname, "src", "index.ts"),
+    },
+    output: {
+      path: path.join(__dirname, "dist"),
+      filename: "index.js",
+      library: "EventvisorTimestampModule",
+      libraryTarget: "umd",
+      globalObject: "this",
+    },
+    mode: "production",
+    devtool: "source-map",
+    resolve: {
+      extensions: [".ts", ".tsx", ".js"],
+    },
+    module: {
+      rules: [
+        {
+          test: /\.(ts|tsx)$/,
+          exclude: /(node_modules)/,
+          use: [
+            {
+              loader: "ts-loader",
+              options: {
+                configFile: path.join(__dirname, "tsconfig.cjs.json"),
+                transpileOnly: true,
+              },
+            },
+          ],
+        },
+      ],
+    },
+    performance: {
+      hints: false,
+    },
+    optimization: {
+      minimize: true,
+    },
+  },
+
+  // esm
+  {
+    entry: path.join(__dirname, "src", "index.ts"),
+    output: {
+      path: path.join(__dirname, "dist"),
+      filename: "index.mjs",
+      library: {
+        type: "module",
+      },
+    },
+    experiments: {
+      outputModule: true,
+    },
+    mode: "production",
+    devtool: "source-map",
+    resolve: {
+      extensions: [".ts", ".tsx", ".js"],
+    },
+    module: {
+      rules: [
+        {
+          test: /\.(ts|tsx)$/,
+          exclude: /(node_modules)/,
+          loader: "ts-loader",
+          options: {
+            configFile: path.join(__dirname, "tsconfig.esm.json"),
+          },
+        },
+      ],
+    },
+    performance: {
+      hints: false,
+    },
+  },
+];

--- a/package-lock.json
+++ b/package-lock.json
@@ -122,6 +122,14 @@
         "@eventvisor/sdk": "0.2.1"
       }
     },
+    "modules/module-timestamp": {
+      "name": "@eventvisor/module-timestamp",
+      "version": "0.2.1",
+      "license": "MIT",
+      "devDependencies": {
+        "@eventvisor/sdk": "0.2.1"
+      }
+    },
     "modules/module-uuid": {
       "name": "@eventvisor/module-uuid",
       "version": "0.2.1",
@@ -1418,6 +1426,10 @@
     },
     "node_modules/@eventvisor/module-pixel": {
       "resolved": "modules/module-pixel",
+      "link": true
+    },
+    "node_modules/@eventvisor/module-timestamp": {
+      "resolved": "modules/module-timestamp",
       "link": true
     },
     "node_modules/@eventvisor/module-uuid": {


### PR DESCRIPTION
## What's done

- Introduced a new `module-timestamp`

## Installation

```
$ npm install --save @eventvisor/module-timestamp
```

## Setting up SDK

```js
import { createInstance } from "@eventvisor/sdk";
import { createTImestampModule } from "@eventvisor/module-timestamp";

const eventvisor = createInstance({
  modules: [
    createTimestampModule(),
  ],
})l
```

## Usage

Use as lookup in conditions and transforms: https://eventvisor.org/docs/lookups/

```yml
# ...

transforms:
  - type: set
    target: someTimestampProperty
    lookup: timestamp
```

Possible lookup values:

- `timestamp`: uses default ISO 8601 with offset format like `2025-10-01T22:37:09.760+02:00`
- `timestamp.epoch`: unix timestamp in seconds
- `timestamp.epoch_ms`: unix timestamp in milliseconds