### PR TITLE
feat: pass full error object to transports

### DIFF
--- a/packages/sdk/src/instance.ts
+++ b/packages/sdk/src/instance.ts
@@ -227,8 +227,6 @@ export class Eventvisor {
         await this.setAttributeAsync(action.name, action.value);
       } else if (action.type === "removeAttribute") {
         await this.removeAttributeAsync(action.name);
-      } else if (action.type === "removeAttribute") {
-        await this.removeAttributeAsync(action.name);
       }
     } catch (error) {
       this.logger.error(`Error processing queue`, {
@@ -333,6 +331,7 @@ export class Eventvisor {
     /**
      * Validate
      */
+    let error: Error | undefined = value instanceof Error ? value : undefined;
     const validationResult = await this.validator.validate(eventSchema, value);
 
     if (!validationResult.valid) {
@@ -572,6 +571,7 @@ export class Eventvisor {
         eventName,
         transportBody,
         eventLevel,
+        error,
       );
     }
 

--- a/packages/sdk/src/modulesManager.ts
+++ b/packages/sdk/src/modulesManager.ts
@@ -35,6 +35,7 @@ export interface TransportOptions {
   eventName: EventName;
   eventLevel?: EventLevel;
   payload: Value; // @TODO: rename to body?
+  error?: Error;
 }
 
 export interface ReadFromStorageOptions {
@@ -199,6 +200,7 @@ export class ModulesManager {
     eventName: EventName,
     payload: Value,
     eventLevel?: EventLevel,
+    error?: Error,
   ): Promise<void> {
     const [moduleName, key] = fullKey.split("."); // eslint-disable-line
 
@@ -207,7 +209,7 @@ export class ModulesManager {
     if (moduleInstance && moduleInstance.transport) {
       try {
         return await moduleInstance.transport(
-          { destinationName, eventName, eventLevel, payload },
+          { destinationName, eventName, eventLevel, payload, error },
           this.getModuleDependencies(),
         );
       } catch (error) {


### PR DESCRIPTION
## Background

- Eventvisor tracks errors and events the same way: https://eventvisor.org/docs/use-cases/tracking-errors/
- But certain third-party analytics services treat tracking error objects different

## What's done

To make it easy for integrating with third-party services for error tracking, next to transformed tracked error object, the original error object will be passed to transports: https://eventvisor.org/docs/transports/