### PR TITLE
feat: export Value type from SDK

### DIFF
--- a/packages/core/src/generate-code/typescript/index.ts
+++ b/packages/core/src/generate-code/typescript/index.ts
@@ -132,8 +132,7 @@ ${generatedEvents.map(({ entityName, interfaceName }) => `  ${entityName}: ${int
   /**
    * Index
    */
-  let indexContent = `import type { Eventvisor } from "@eventvisor/sdk";
-import type { Value } from "@eventvisor/types";
+  let indexContent = `import type { Eventvisor, Value } from "@eventvisor/sdk";
 
 import type { Events } from "./events";
 import type { Attributes } from "./attributes";

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -12,3 +12,5 @@ export * from "./effectsManager";
 
 export * from "./murmurhash";
 export * from "./compareVersions";
+
+export type { Value } from "@eventvisor/types";


### PR DESCRIPTION
## What's done

- Export `Value` coming originally from `@eventvisor/types` from `@eventvisor/sdk`
- This makes code generation simpler: https://eventvisor.org/docs/code-generation/